### PR TITLE
Add functionality to display pitches of an establishment

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import { Routes } from '@angular/router';
 import { AuthGuard } from './core/guards/auth.guard';
 import { PublicLayoutComponent } from './layouts/public-layout/public-layout.component';
 import { JugadorLayoutComponent } from './layouts/jugador-layout/jugador-layout.component';
+import { EstablecimientoLayoutComponent } from './layouts/establecimiento-layout/establecimiento-layout.component';
 import { AdminLayoutComponent } from './layouts/admin-layout/admin-layout.component';
 import { authRoutes } from './features/auth/auth.routes';
 
@@ -21,6 +22,15 @@ export const routes: Routes = [
         data: { role: 'player' },
         children: [
             { path: '', loadChildren: () => import('./features/jugador/jugador.routes').then(r => r.jugadorRoutes) }
+        ],
+    },
+    {
+        path: 'establecimiento',
+        component: EstablecimientoLayoutComponent,
+        canActivate: [AuthGuard],
+        data: { role: 'establishment' },
+        children: [
+            { path: '', loadChildren: () => import('./features/establecimiento/establecimiento.routes').then(r => r.establecimientoRoutes) }
         ],
     },
     {

--- a/src/app/features/establecimiento/campos/campos.component.html
+++ b/src/app/features/establecimiento/campos/campos.component.html
@@ -1,0 +1,9 @@
+<h2>Campos</h2>
+<ul>
+    <li *ngFor="let pitch of pitches">
+        {{ pitch.name }} - {{ pitch.location }}
+    </li>
+</ul>
+<div *ngIf="error" class="error">
+    {{ error }}
+</div>

--- a/src/app/features/establecimiento/campos/campos.component.scss
+++ b/src/app/features/establecimiento/campos/campos.component.scss
@@ -1,0 +1,3 @@
+.error {
+    color: red;
+}

--- a/src/app/features/establecimiento/campos/campos.component.ts
+++ b/src/app/features/establecimiento/campos/campos.component.ts
@@ -1,0 +1,28 @@
+import { Component, OnInit } from '@angular/core';
+import { PitchsService } from './../../establecimiento/campos/campos.service';
+import { Pitch } from '../../../core/models/pitch.model';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-establecimiento-campos',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './campos.component.html',
+  styleUrl: './campos.component.scss'
+})
+export class CamposComponent implements OnInit {
+  pitches: Pitch[] = [];
+  error: string | null = null;
+
+  constructor(private pitchesService: PitchsService) { }
+
+  ngOnInit(): void {
+    this.pitchesService.getPitches().subscribe({
+      next: (pitches) => this.pitches = pitches,
+      error: (err) => {
+        this.error = 'Error al obtener los campos: ' + (err.error?.message || err.message);
+        console.error('Error al obtener campos:', err);
+      }
+    });
+  }
+}

--- a/src/app/features/establecimiento/campos/campos.service.ts
+++ b/src/app/features/establecimiento/campos/campos.service.ts
@@ -1,0 +1,18 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../environments/environment';
+import { Observable } from 'rxjs';
+import { Pitch } from '../../../core/models/pitch.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class PitchsService {
+  private apiUrl = `${environment.apiUrl}/pitches`;
+
+  constructor(private http: HttpClient) { }
+
+  getPitches(): Observable<Pitch[]> {
+    return this.http.get<Pitch[]>(this.apiUrl);
+  }
+}

--- a/src/app/features/establecimiento/establecimiento.routes.ts
+++ b/src/app/features/establecimiento/establecimiento.routes.ts
@@ -1,0 +1,7 @@
+import { Routes } from '@angular/router';
+import { CamposComponent } from './campos/campos.component';
+
+export const establecimientoRoutes: Routes = [
+    { path: 'campos', component: CamposComponent },
+    { path: '', redirectTo: 'campos', pathMatch: 'full' }
+];


### PR DESCRIPTION
- Configuración de las rutas en app.routes.ts y establecimiento.routes.ts para cargar la vista /establecimiento/campos.
- Implementación de CamposComponent con su plantilla (campos.component.html) y estilos (campos.component.scss) para mostrar los campos.
- Creación de PitchsService para obtener los campos desde el endpoint /pitches del backend.