### PR TITLE
Refactor API URLs and Move createReservation to ReservasService

### DIFF
--- a/src/app/features/admin/usuarios/usuarios.service.ts
+++ b/src/app/features/admin/usuarios/usuarios.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../environments/environment';
 import { Observable } from 'rxjs';
 import { User } from '../../../core/models/user.model';
 
@@ -7,7 +8,7 @@ import { User } from '../../../core/models/user.model';
   providedIn: 'root'
 })
 export class UsuariosService {
-  private apiUrl = 'http://localhost:8000/api/users';
+  private apiUrl = `${environment.apiUrl}/admin/users`
 
   constructor(private http: HttpClient) { }
 

--- a/src/app/features/establecimiento/campos/campos.service.ts
+++ b/src/app/features/establecimiento/campos/campos.service.ts
@@ -8,7 +8,7 @@ import { Pitch } from '../../../core/models/pitch.model';
   providedIn: 'root'
 })
 export class PitchsService {
-  private apiUrl = `${environment.apiUrl}/pitches`;
+  private apiUrl = `${environment.apiUrl}/establishment/pitches`;
 
   constructor(private http: HttpClient) { }
 

--- a/src/app/features/jugador/campos/campos.service.ts
+++ b/src/app/features/jugador/campos/campos.service.ts
@@ -9,7 +9,7 @@ import { Reservation } from '../../../core/models/reservation.model';
   providedIn: 'root'
 })
 export class PitchsService {
-  private apiUrl = `${environment.apiUrl}/pitches`;
+  private apiUrl = `${environment.apiUrl}/player/pitches`;
 
   constructor(private http: HttpClient) { }
 

--- a/src/app/features/jugador/campos/campos.service.ts
+++ b/src/app/features/jugador/campos/campos.service.ts
@@ -3,7 +3,6 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { Observable } from 'rxjs';
 import { Pitch } from '../../../core/models/pitch.model';
-import { Reservation } from '../../../core/models/reservation.model';
 
 @Injectable({
   providedIn: 'root'
@@ -15,10 +14,6 @@ export class PitchsService {
 
   getPitches(): Observable<Pitch[]> {
     return this.http.get<Pitch[]>(this.apiUrl);
-  }
-
-  createReservation(reservation: { pitch_id: number, start_at: string, duration: number }): Observable<Reservation> {
-    return this.http.post<Reservation>(this.apiUrl, reservation);
   }
 
   filterPitches(pitches: Pitch[], search: string = ''): Pitch[] {

--- a/src/app/features/jugador/campos/reservar/reservar.component.ts
+++ b/src/app/features/jugador/campos/reservar/reservar.component.ts
@@ -22,6 +22,7 @@ export class ReservaFormComponent implements OnInit {
 
   constructor(
     private pitchsService: PitchsService,
+    private reservasService: ReservasService,
     private router: Router,
     private route: ActivatedRoute
   ) {}
@@ -53,7 +54,7 @@ export class ReservaFormComponent implements OnInit {
       duration: this.duration
     };
 
-    this.pitchsService.createReservation(reservationData).subscribe({
+    this.reservasService.createReservation(reservationData).subscribe({
       next: (response) => {
         this.success = 'Reserva creada con éxito.';
         setTimeout(() => this.router.navigate(['/jugador/reservas']), 2000);

--- a/src/app/features/jugador/perfil/perfil.service.ts
+++ b/src/app/features/jugador/perfil/perfil.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../../../../environments/environment';
 import { Observable } from 'rxjs';
 import { User } from '../../../core/models/user.model';
 
@@ -7,7 +8,7 @@ import { User } from '../../../core/models/user.model';
   providedIn: 'root'
 })
 export class PerfilService {
-  private apiUrl = 'http://localhost:8000/api/profile';
+  private apiUrl = `${environment.apiUrl}/player/profile`;
 
   constructor(private http: HttpClient) { }
 

--- a/src/app/features/jugador/reservas/reservas.service.ts
+++ b/src/app/features/jugador/reservas/reservas.service.ts
@@ -8,7 +8,7 @@ import { Reservation } from '../../../core/models/reservation.model';
   providedIn: 'root'
 })
 export class ReservasService {
-  private apiUrl = `${environment.apiUrl}/reservations`;
+  private apiUrl = `${environment.apiUrl}/player/reservations`;
 
   constructor(private http: HttpClient) { }
 

--- a/src/app/features/jugador/reservas/reservas.service.ts
+++ b/src/app/features/jugador/reservas/reservas.service.ts
@@ -15,4 +15,8 @@ export class ReservasService {
   getReservations(): Observable<Reservation[]> {
     return this.http.get<Reservation[]>(this.apiUrl);
   }
+
+  createReservation(reservation: { pitch_id: number, start_at: string, duration: number }): Observable<Reservation> {
+    return this.http.post<Reservation>(this.apiUrl, reservation);
+  }
 }


### PR DESCRIPTION
Esta PR refactoriza las URLs de los servicios para incluir prefijos basados en roles y mueve la lógica de creación de reservas al servicio adecuado.

**Cambios principales:**
- Actualización de URLs en los servicios para incluir prefijos según el rol del usuario: 
  - `PitchsService`: Cambiado a `/establishment/pitches`.
  - `UsuariosService`: Cambiado a `/admin/users`.
  - `PitchsService`: Cambiado a `/player/pitches`.
  - `ReservasService`: Cambiado a `/player/reservations`.
  - `PerfilService`: Cambiado a `/player/profile`.
- Movido el método `createReservation` de `PitchsService` a `ReservasService`, mejorando la separación de responsabilidades.
- Actualizado `ReservaFormComponent` para usar `ReservasService` en lugar de `PitchsService` para crear reservas.

**Pruebas realizadas:**
- Verificado que las nuevas URLs funcionan correctamente con el backend.
- Comprobado que los jugadores pueden crear reservas usando el formulario actualizado.
- Confirmado que la lista de reservas y campos se muestra correctamente.