### PR TITLE
Adapt Frontend to Standardized API Response Structure

### DIFF
--- a/src/app/core/models/api-response.model.ts
+++ b/src/app/core/models/api-response.model.ts
@@ -1,0 +1,43 @@
+import { User } from "./user.model";
+import { Pitch } from "./pitch.model";
+import { Reservation } from "./reservation.model";
+
+export interface UsersResponse {
+    message: string;
+    users: User[];
+}
+
+export interface UserResponse {
+    message: string;
+    user: User;
+}
+
+export interface PitchesResponse {
+    message: string;
+    pitches: Pitch[];
+}
+
+export interface ReservationsResponse {
+    message: string;
+    reservations: Reservation[];
+}
+
+export interface ReservationResponse {
+    message: string;
+    reservation: Reservation;
+}
+
+export interface AvailableDatesResponse {
+    message: string;
+    dates: { date: string; available: boolean }[];
+}
+
+export interface AvailableTimesResponse {
+    message: string;
+    availableTimes: string[];
+}
+
+export interface AvailabilityResponse {
+    message?: string;
+    available: boolean;
+}

--- a/src/app/features/admin/usuarios/usuarios.component.ts
+++ b/src/app/features/admin/usuarios/usuarios.component.ts
@@ -18,7 +18,7 @@ export class UsuariosComponent implements OnInit {
 
   ngOnInit(): void {
     this.usuariosService.getUsuarios().subscribe({
-      next: (users) => this.users = users,
+      next: (response) => this.users = response.users,
       error: (err) => this.error = 'Error al cargar los usuarios: ' + (err.error?.message || err.message)
     });
   }

--- a/src/app/features/admin/usuarios/usuarios.service.ts
+++ b/src/app/features/admin/usuarios/usuarios.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { Observable } from 'rxjs';
-import { User } from '../../../core/models/user.model';
+import { UsersResponse } from '../../../core/models/api-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +12,7 @@ export class UsuariosService {
 
   constructor(private http: HttpClient) { }
 
-  getUsuarios(): Observable<User[]> {
-    return this.http.get<User[]>(this.apiUrl);
+  getUsuarios(): Observable<UsersResponse> {
+    return this.http.get<UsersResponse>(this.apiUrl);
   }
 }

--- a/src/app/features/establecimiento/campos/campos.component.ts
+++ b/src/app/features/establecimiento/campos/campos.component.ts
@@ -18,7 +18,7 @@ export class CamposComponent implements OnInit {
 
   ngOnInit(): void {
     this.pitchesService.getPitches().subscribe({
-      next: (pitches) => this.pitches = pitches,
+      next: (response) => this.pitches = response.pitches,
       error: (err) => {
         this.error = 'Error al obtener los campos: ' + (err.error?.message || err.message);
         console.error('Error al obtener campos:', err);

--- a/src/app/features/establecimiento/campos/campos.service.ts
+++ b/src/app/features/establecimiento/campos/campos.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { Observable } from 'rxjs';
-import { Pitch } from '../../../core/models/pitch.model';
+import { PitchesResponse } from '../../../core/models/api-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +12,7 @@ export class PitchsService {
 
   constructor(private http: HttpClient) { }
 
-  getPitches(): Observable<Pitch[]> {
-    return this.http.get<Pitch[]>(this.apiUrl);
+  getPitches(): Observable<PitchesResponse> {
+    return this.http.get<PitchesResponse>(this.apiUrl);
   }
 }

--- a/src/app/features/jugador/campos/campos.service.ts
+++ b/src/app/features/jugador/campos/campos.service.ts
@@ -2,8 +2,9 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { Observable, BehaviorSubject, combineLatest } from 'rxjs';
-import { debounceTime, distinctUntilChanged, map } from 'rxjs/operators';
+import { debounceTime, distinctUntilChanged, map, tap } from 'rxjs/operators';
 import { Pitch } from '../../../core/models/pitch.model';
+import { PitchesResponse } from '../../../core/models/api-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -22,12 +23,9 @@ export class PitchsService {
 
   constructor(private http: HttpClient) { }
 
-  getPitches(): Observable<Pitch[]> {
-    return this.http.get<Pitch[]>(this.apiUrl).pipe(
-      map(pitches => {
-        this.pitchesSubject.next(pitches); // Actualiza el subject con los datos obtenidos
-        return pitches;
-      })
+  getPitches(): Observable<PitchesResponse> {
+    return this.http.get<PitchesResponse>(this.apiUrl).pipe(
+      tap(response => this.pitchesSubject.next(response.pitches)) // Actualiza el subject con los datos obtenidos
     );
   }
 

--- a/src/app/features/jugador/campos/detalle/detalle.component.ts
+++ b/src/app/features/jugador/campos/detalle/detalle.component.ts
@@ -25,8 +25,8 @@ export class CampoDetallesComponent implements OnInit {
     const pitchId = this.route.snapshot.paramMap.get('id');
     if (pitchId) {
       this.pitchsService.getPitches().subscribe({
-        next: (pitches) => {
-          this.pitch = pitches.find(p => p.id === +pitchId) || null;
+        next: (response) => {
+          this.pitch = response.pitches.find(p => p.id === +pitchId) || null;
           if (!this.pitch) {
             this.error = 'Campo no encontrado.';
           }

--- a/src/app/features/jugador/campos/reservar/calendar/calendar.component.ts
+++ b/src/app/features/jugador/campos/reservar/calendar/calendar.component.ts
@@ -61,9 +61,9 @@ export class CalendarComponent implements OnInit {
 
     private loadAvailableDates(): void {
         this.reservasService.getAvailableDates(this.pitch!.id, this.minDate, this.maxDate).subscribe({
-            next: (availableDatesResponse) => {
+            next: (response) => {
                 const availableDatesMap = new Map<string, boolean>();
-                availableDatesResponse.forEach(date => {
+                response.dates.forEach(date => {
                     availableDatesMap.set(date.date, date.available);
                 });
 

--- a/src/app/features/jugador/campos/reservar/reservar.component.ts
+++ b/src/app/features/jugador/campos/reservar/reservar.component.ts
@@ -43,8 +43,8 @@ export class ReservaFormComponent implements OnInit {
     const pitchId = this.route.snapshot.paramMap.get('pitchId');
     if (pitchId) {
       this.pitchsService.getPitches().subscribe({
-        next: (pitches) => {
-          this.pitch = pitches.find(p => p.id === +pitchId) || null;
+        next: (response) => {
+          this.pitch = response.pitches.find(p => p.id === +pitchId) || null;
           if (!this.pitch) {
             this.error = 'Campo no encontrado.';
           } else {

--- a/src/app/features/jugador/perfil/perfil.component.ts
+++ b/src/app/features/jugador/perfil/perfil.component.ts
@@ -18,7 +18,7 @@ export class PerfilComponent implements OnInit {
 
   ngOnInit(): void {
     this.perfilService.getProfile().subscribe({
-      next: (user) => this.user = user,
+      next: (response) => this.user = response.user,
       error: (err) => {
         this.error = 'Error al obtener el perfil: ' + (err.error?.message || err.message);
         console.error('Error al obtener el perfil:', err);

--- a/src/app/features/jugador/perfil/perfil.service.ts
+++ b/src/app/features/jugador/perfil/perfil.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { Observable } from 'rxjs';
-import { User } from '../../../core/models/user.model';
+import { UserResponse } from '../../../core/models/api-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -12,7 +12,7 @@ export class PerfilService {
 
   constructor(private http: HttpClient) { }
 
-  getProfile(): Observable<User> {
-    return this.http.get<User>(this.apiUrl);
+  getProfile(): Observable<UserResponse> {
+    return this.http.get<UserResponse>(this.apiUrl);
   }
 }

--- a/src/app/features/jugador/reservas/reservas.component.ts
+++ b/src/app/features/jugador/reservas/reservas.component.ts
@@ -11,14 +11,14 @@ import { CommonModule } from '@angular/common';
   styleUrl: './reservas.component.scss'
 })
 export class ReservasComponent implements OnInit {
-  reservations: Reservation[] = [];;
+  reservations: Reservation[] = [];
   error: string | null = null;
 
   constructor(private reservasService: ReservasService) { }
 
   ngOnInit(): void {
     this.reservasService.getReservations().subscribe({
-      next: (reservations) => this.reservations = reservations,
+      next: (response) => this.reservations = response.reservations || [],
       error: (err) => {
         this.error = 'Error al obtener las reservas: ' + (err.error?.message || err.message);
         console.error('Error al obtener reservas:', err);

--- a/src/app/features/jugador/reservas/reservas.service.ts
+++ b/src/app/features/jugador/reservas/reservas.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { Observable } from 'rxjs';
-import { Reservation } from '../../../core/models/reservation.model';
+import { ReservationsResponse, ReservationResponse, AvailabilityResponse, AvailableTimesResponse, AvailableDatesResponse } from '../../../core/models/api-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -12,26 +12,26 @@ export class ReservasService {
 
   constructor(private http: HttpClient) { }
 
-  getReservations(): Observable<Reservation[]> {
-    return this.http.get<Reservation[]>(this.apiUrl);
+  getReservations(): Observable<ReservationsResponse> {
+    return this.http.get<ReservationsResponse>(this.apiUrl);
   }
 
-  createReservation(reservation: { pitch_id: number, start_at: string, duration: number }): Observable<Reservation> {
-    return this.http.post<Reservation>(this.apiUrl, reservation);
+  createReservation(reservation: { pitch_id: number; start_at: string; duration: number }): Observable<ReservationResponse> {
+    return this.http.post<ReservationResponse>(this.apiUrl, reservation);
   }
 
-  checkAvailability(reservation: { pitch_id: number, start_at: string, duration: number }): Observable<{ available: boolean, message?: string }> {
-    return this.http.post<{ available: boolean, message?: string }>(`${this.apiUrl}/check`, reservation);
+  checkAvailability(reservation: { pitch_id: number; start_at: string; duration: number }): Observable<AvailabilityResponse> {
+    return this.http.post<AvailabilityResponse>(`${this.apiUrl}/check`, reservation);
   }
 
-  getAvailableTimes(pitchId: number, date: string): Observable<{ availableTimes: string[] }> {
-    return this.http.get<{ availableTimes: string[] }>(`${this.apiUrl}/available-times`, {
+  getAvailableTimes(pitchId: number, date: string): Observable<AvailableTimesResponse> {
+    return this.http.get<AvailableTimesResponse>(`${this.apiUrl}/available-times`, {
       params: { pitch_id: pitchId.toString(), date }
     });
   }
 
-  getAvailableDates(pitchId: number, startDate: string, endDate: string): Observable<{ date: string, available: boolean }[]> {
-    return this.http.get<{ date: string, available: boolean }[]>(`${this.apiUrl}/available-dates`, {
+  getAvailableDates(pitchId: number, startDate: string, endDate: string): Observable<AvailableDatesResponse> {
+    return this.http.get<AvailableDatesResponse>(`${this.apiUrl}/available-dates`, {
       params: { pitch_id: pitchId.toString(), start_date: startDate, end_date: endDate }
     });
   }


### PR DESCRIPTION
Este pull request adapta el frontend para manejar la estructura estandarizada de respuestas de la API introducida en el backend, donde las respuestas ahora incluyen una clave message y una clave de datos (por ejemplo, users, pitches). Se añadió un nuevo archivo api-response.model.ts para definir las interfaces de respuesta, y se actualizaron los servicios y componentes en consecuencia.

Cambios:
Se añade el modelo api-response para manejar respuestas estandarizadas de la API.

Se adaptan los servicios de jugadores, establecimientos y administradores para manejar respuestas estandarizadas de la API.

Se actualizan los componentes para manejar la estructura de respuesta estandarizada de la API.

Objetivo:
Asegurar que el frontend procese correctamente la nueva estructura de respuesta de la API.

Mejorar la seguridad de tipos mediante interfaces de respuesta.