### PR TITLE
Fix Logout Error by Checking Authentication Before POST Request

### DIFF
--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -90,12 +90,15 @@ export class AuthService {
   }
 
   logout(): void {
+    if (this.isAuthenticated()) {
+      this.http.post(`${this.apiUrl}/logout`, {}).subscribe({
+        error: (err) => console.error('Error al cerrar sesión:', err)
+      });
+    }
+
     this.currentUser = null;
     localStorage.removeItem('user');
     localStorage.removeItem('auth_token');
-    this.http.post(`${this.apiUrl}/logout`, {}).subscribe({
-      error: (err) => console.error('Error al cerrar sesión:', err)
-    });
   }
 
   getCurrentUser(): User | null {


### PR DESCRIPTION
Este pull request corrige un error en la consola que ocurría cuando el método logout en AuthService realizaba una petición POST al endpoint /logout sin un token de autenticación válido. La corrección añade una verificación con isAuthenticated() antes de enviar la solicitud.

Cambios:
Se corrige el error en logout comprobando la autenticación antes de hacer la solicitud POST.

Objetivo:
Evitar solicitudes POST innecesarias a /logout cuando el usuario no está autenticado.

Eliminar el error resultante en la consola.