### PR TITLE
Add Stripe Payment Integration to Frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@fullcalendar/core": "^6.1.17",
         "@fullcalendar/daygrid": "^6.1.17",
         "@fullcalendar/interaction": "^6.1.17",
+        "@stripe/stripe-js": "^7.3.1",
         "bootstrap": "^5.3.5",
         "date-fns": "^4.1.0",
         "rxjs": "~7.8.0",
@@ -4968,6 +4969,15 @@
       "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@stripe/stripe-js": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-7.3.1.tgz",
+      "integrity": "sha512-pTzb864TQWDRQBPLgSPFRoyjSDUqpCkbEgTzpsjiTjGz1Z5SxZNXJek28w1s6Dyry4CyW4/Izj5jHE/J9hCJYQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.16"
+      }
     },
     "node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@fullcalendar/core": "^6.1.17",
     "@fullcalendar/daygrid": "^6.1.17",
     "@fullcalendar/interaction": "^6.1.17",
+    "@stripe/stripe-js": "^7.3.1",
     "bootstrap": "^5.3.5",
     "date-fns": "^4.1.0",
     "rxjs": "~7.8.0",

--- a/src/app/core/models/api-response.model.ts
+++ b/src/app/core/models/api-response.model.ts
@@ -41,3 +41,8 @@ export interface AvailabilityResponse {
     message?: string;
     available: boolean;
 }
+
+export interface CreatePaymentIntentResponse {
+    message?: string;
+    client_secret: string;
+}

--- a/src/app/core/services/reservation-state.service.ts
+++ b/src/app/core/services/reservation-state.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+
+interface ReservationData {
+    pitch_id: number;
+    start_at: string;
+    duration: number;
+    client_secret?: string;
+}
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ReservationStateService {
+
+    private reservationData: ReservationData | null = null;
+
+    setReservationData(data: { pitch_id: number; start_at: string; duration: number; client_secret?: string }) {
+        this.reservationData = data;
+    }
+
+    getReservationData() {
+        return this.reservationData;
+    }
+
+    clearReservationData() {
+        this.reservationData = null;
+    }
+}

--- a/src/app/features/jugador/campos/campos.component.html
+++ b/src/app/features/jugador/campos/campos.component.html
@@ -16,8 +16,8 @@
       <p><strong>Ubicación:</strong> {{ pitch.location }}</p>
       <p><strong>Establecimiento:</strong> {{ pitch?.establishment?.name }}</p>
       <div class="actions">
-        <a [routerLink]="['/jugador/campos', pitch.id, 'detalles']" class="btn btn-details">Ver Detalles</a>
-        <a [routerLink]="['/jugador/reserva', pitch.id]" class="btn btn-reserve">Reservar</a>
+        <a [routerLink]="['/jugador/campo', pitch.id, 'detalles']" class="btn btn-details">Ver Detalles</a>
+        <a [routerLink]="['/jugador/campo', pitch.id, 'reservar']" class="btn btn-reserve">Reservar</a>
       </div>
     </div>
     }

--- a/src/app/features/jugador/campos/reservar/pagar/pagar.component.html
+++ b/src/app/features/jugador/campos/reservar/pagar/pagar.component.html
@@ -1,0 +1,21 @@
+<h2>Pago de la Reserva</h2>
+
+<app-loading [isLoading]="isLoading"></app-loading>
+
+<div class="content">
+  
+  <label for="amount">Precio:</label>
+  <label>{{ amount | currency:'EUR':'symbol':'1.2-2' }}</label>
+
+  <label>Datos de la tarjeta:</label>
+  <div id="card-element" class="card-element"></div>
+
+  <button type="submit" (click)="onSubmit()" [disabled]="isLoading">Pagar y Reservar</button>
+
+</div>
+@if (error) {
+<div class="alert alert-danger">{{ error }}</div>
+}
+@if (success) {
+<div class="alert alert-success">{{ success }}</div>
+}

--- a/src/app/features/jugador/campos/reservar/pagar/pagar.component.scss
+++ b/src/app/features/jugador/campos/reservar/pagar/pagar.component.scss
@@ -1,0 +1,42 @@
+.error {
+  color: red;
+  margin-top: 10px;
+}
+
+.success {
+  color: green;
+  margin-top: 10px;
+}
+
+div {
+  margin-bottom: 15px;
+}
+
+label {
+  display: block;
+  margin-bottom: 5px;
+}
+
+button {
+  padding: 10px 20px;
+  background-color: #007bff;
+  color: white;
+  border: none;
+  cursor: pointer;
+}
+
+button:hover {
+  background-color: #0056b3;
+}
+
+button:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
+}
+
+.card-element {
+  border: 1px solid #ccc;
+  padding: 10px;
+  border-radius: 4px;
+  margin-bottom: 10px;
+}

--- a/src/app/features/jugador/campos/reservar/pagar/pagar.component.ts
+++ b/src/app/features/jugador/campos/reservar/pagar/pagar.component.ts
@@ -1,0 +1,164 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LoadingComponent } from '../../../../../shared/components/loading/loading.component';
+import { ActivatedRoute, Router } from '@angular/router';
+import { ReservasService } from '../../../reservas/reservas.service';
+import { ReservationStateService } from '../../../../../core/services/reservation-state.service';
+import { PitchsService } from '../../campos.service';
+import { Pitch } from '../../../../../core/models/pitch.model';
+import { loadStripe, Stripe, StripeElements, StripeCardElement } from '@stripe/stripe-js';
+import { environment } from '../../../../../../environments/environment';
+
+@Component({
+  selector: 'app-jugador-campos-reservar-pagar',
+  standalone: true,
+  imports: [CommonModule, LoadingComponent],
+  templateUrl: './pagar.component.html',
+  styleUrls: ['./pagar.component.scss']
+})
+export class PagarComponent implements OnInit, OnDestroy {
+  stripe: Stripe | null = null;
+  elements: StripeElements | null = null;
+  card: StripeCardElement | null = null;
+  error: string | null = null;
+  success: string | null = null;
+  isLoading: boolean = true;
+  pitch: Pitch | null = null;
+  amount: number = 30;
+
+  constructor(
+    private reservationStateService: ReservationStateService,
+    private reservasService: ReservasService,
+    private pitchsService: PitchsService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) { }
+
+  async ngOnInit(): Promise<void> {
+    // Cargar Stripe.js
+    this.stripe = await loadStripe(environment.stripePublicKey);
+    if (!this.stripe) {
+      this.error = 'Error al cargar la biblioteca de Stripe. Verifica tu clave pública.';
+      this.isLoading = false;
+      return;
+    }
+
+    this.error = null;
+
+    const pitchId = this.route.snapshot.paramMap.get('pitchId');
+    if (pitchId) {
+      this.pitchsService.getPitches().subscribe({
+        next: (response) => {
+          this.pitch = response.pitches.find(p => p.id === +pitchId) || null;
+          if (!this.pitch) {
+            this.error = 'Campo no encontrado.';
+          }
+        },
+        error: (err) => this.error = 'Error al cargar el campo: ' + (err.error?.message || err.message),
+        complete: () => this.isLoading = false
+      });
+    } else {
+      this.error = 'ID del campo no proporcionado.';
+      this.isLoading = false;
+    }
+
+    const reservationData = this.reservationStateService.getReservationData();
+    if (!reservationData || !reservationData.client_secret) {
+      this.error = 'Datos de reserva no válidos. Por favor, vuelve a intentarlo.';
+      this.isLoading = false;
+      return;
+    }
+
+    try {
+      if (reservationData && reservationData.client_secret) {
+
+        if (this.stripe) {
+          this.elements = this.stripe.elements();
+          this.card = this.elements.create('card', {
+            style: {
+              base: {
+                fontSize: '16px',
+                color: '#32325d',
+                '::placeholder': { color: '#aab7c4' }
+              }
+            }
+          });
+          const cardElement = document.getElementById('card-element');
+          if (cardElement) {
+            this.card.mount('#card-element');
+          } else {
+            this.error = 'El elemento de la tarjeta no se encontró en el DOM.';
+          }
+        }
+      } else {
+        throw new Error('No se recibió un client_secret válido del servidor.');
+      }
+    } catch (err: any) {
+      this.error = 'Error al iniciar el pago: ' + (err.error?.message || err.message || 'Intenta de nuevo más tarde');
+    }
+
+  }
+
+  ngOnDestroy() {
+    if (this.card) this.card.unmount();
+  }
+
+  async onSubmit(): Promise<void> {
+    if (!this.stripe || !this.card || this.error) {
+      this.error = 'No se puede realizar el pago. Verifica el formulario.';
+      return;
+    }
+
+    this.isLoading = true;
+    const reservationData = this.reservationStateService.getReservationData();
+    if (!reservationData || !reservationData.client_secret) {
+      this.error = 'Datos de reserva no válidos.';
+      this.isLoading = false;
+      return;
+    }
+
+    const result = await this.stripe.confirmCardPayment(reservationData.client_secret, {
+      payment_method: {
+        card: this.card,
+        billing_details: {
+          name: 'Usuario de prueba'
+        }
+      }
+    });
+
+    if (result.error) {
+      this.error = 'Error en el pago: ' + result.error.message;
+      this.isLoading = false;
+      return;
+    }
+
+    if (result.paymentIntent.status === 'succeeded') {
+      const reservationPayload = {
+        pitch_id: reservationData.pitch_id,
+        start_at: reservationData.start_at,
+        duration: reservationData.duration,
+        stripe_payment_intent_id: result.paymentIntent.id
+      };
+
+      this.reservasService.createReservation(reservationPayload).subscribe({
+        next: (response) => {
+          this.success = response.message || 'Reserva creada con éxito';
+          this.reservationStateService.clearReservationData();
+          setTimeout(() => {
+            this.router.navigate(['/jugador/reservas'], { queryParams: { success: this.success } });
+          }, 1000);
+        },
+        error: (err) => {
+          this.error = 'Error al crear la reserva: ' + (err.error?.message || err.message);
+          this.isLoading = false;
+        },
+        complete: () => {
+          this.isLoading = false;
+        }
+      });
+    } else {
+      this.error = 'El pago no se completó correctamente.';
+      this.isLoading = false;
+    }
+  }
+}

--- a/src/app/features/jugador/campos/reservar/reservar.component.html
+++ b/src/app/features/jugador/campos/reservar/reservar.component.html
@@ -12,7 +12,7 @@
     <app-calendar [pitch]="pitch" [minDate]="minDate" [maxDate]="maxDate"
       (dateSelected)="selectedDate = $event; updateAvailableTimes()"></app-calendar>
 
-    <form (ngSubmit)="onSubmit()">
+    <form (ngSubmit)="createPaymentIntent()">
       <div>
         <label for="date">Fecha:</label>
         <input
@@ -59,15 +59,20 @@
           <option value="120">2 horas</option>
         </select>
       </div>
-      <button type="submit" [disabled]="!isFormValid || error !== null">Reservar</button>
+      @if (isFormValid) {
+      <button type="button" (click)="createPaymentIntent()">Iniciar Pago</button>
+      }
+      @if (error) {
+      <div class="alert alert-danger">{{ error }}</div>
+      }
+      @if (success) {
+      <div class="alert alert-success">{{ success }}</div>
+      }
     </form>
   </div>
   }
-  @if (error) {
+  @if (error && !pitch) {
   <div class="alert alert-danger">{{ error }}</div>
-  }
-  @if (success) {
-  <div class="alert alert-success">{{ success }}</div>
   }
 </div>
 }

--- a/src/app/features/jugador/campos/reservar/reservar.component.ts
+++ b/src/app/features/jugador/campos/reservar/reservar.component.ts
@@ -8,6 +8,8 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { CalendarComponent } from './calendar/calendar.component';
 import { format, addDays, startOfToday, isAfter, parseISO } from 'date-fns';
 import { LoadingComponent } from '../../../../shared/components/loading/loading.component';
+import { ReservationStateService } from '../../../../core/services/reservation-state.service';
+import { lastValueFrom } from 'rxjs';
 
 @Component({
   selector: 'app-jugador-campos-reservar',
@@ -32,6 +34,7 @@ export class ReservaFormComponent implements OnInit {
   constructor(
     private pitchsService: PitchsService,
     private reservasService: ReservasService,
+    private reservationStateService: ReservationStateService,
     private router: Router,
     private route: ActivatedRoute
   ) {}
@@ -166,34 +169,37 @@ export class ReservaFormComponent implements OnInit {
     });
   }
 
-  onSubmit(): void {
-    if (!this.isFormValid || this.error) {
-      this.error = 'No se puede realizar la reserva. Verifica la disponibilidad.';
+  async createPaymentIntent(): Promise<void> {
+    if (!this.isFormValid || this.error || !this.pitch) {
+      this.error = 'No se puede iniciar el pago. Verifica la disponibilidad.';
       return;
     }
 
+    this.isLoading = true;
     const startAt = `${this.selectedDate} ${this.selectedTime}:00`;
-    const reservationData = {
-      pitch_id: this.pitch!.id,
+    const paymentIntentData = {
+      pitch_id: this.pitch.id,
       start_at: startAt,
       duration: this.duration
     };
 
-    this.reservasService.createReservation(reservationData).subscribe({
-      next: (response) => {
-        this.success = response.message || null;
-        this.updateAvailableTimes();
-        setTimeout(() => {
-          if (this.success) {
-            this.router.navigate(['/jugador/reservas'], { queryParams: { success: this.success } });
-          } else {
-            this.router.navigate(['/jugador/reservas']);
-          }
-        }, 1000);
-      },
-      error: (err) => {
-        this.error = 'Error al crear la reserva: ' + (err.error?.message || err.message);
+    try {
+      const response = await lastValueFrom(this.reservasService.createPaymentIntent(paymentIntentData));
+      if (response && response.client_secret) {
+        this.reservationStateService.setReservationData({
+          pitch_id: this.pitch.id,
+          start_at: startAt,
+          duration: this.duration,
+          client_secret: response.client_secret
+        });
+        this.router.navigate([`/jugador/campo/${this.pitch.id}/reservar/pagar`]);
+      } else {
+        throw new Error('No se recibió un client_secret válido del servidor.');
       }
-    });
+    } catch (err: any) {
+      this.error = 'Error al iniciar el pago: ' + (err.error?.message || err.message || 'Intenta de nuevo más tarde');
+    } finally {
+      this.isLoading = false;
+    }
   }
 }

--- a/src/app/features/jugador/jugador.routes.ts
+++ b/src/app/features/jugador/jugador.routes.ts
@@ -4,13 +4,14 @@ import { ReservasComponent } from './reservas/reservas.component';
 import { CamposComponent } from './campos/campos.component';
 import { ReservaFormComponent } from './campos/reservar/reservar.component';
 import { CampoDetallesComponent } from './campos/detalle/detalle.component';
+import { PagarComponent } from './campos/reservar/pagar/pagar.component';
 
 export const jugadorRoutes: Routes = [
     { path: 'perfil', component: PerfilComponent },
     { path: 'reservas', component: ReservasComponent },
     { path: 'campos', component: CamposComponent },
-    { path: 'campos/:id/detalles', component: CampoDetallesComponent },
-    { path: 'reserva', component: ReservaFormComponent },
-    { path: 'reserva/:pitchId', component: ReservaFormComponent },
+    { path: 'campo/:id/detalles', component: CampoDetallesComponent },
+    { path: 'campo/:pitchId/reservar', component: ReservaFormComponent },
+    { path: 'campo/:pitchId/reservar/pagar', component: PagarComponent },
     { path: '', redirectTo: 'perfil', pathMatch: 'full' }
 ];

--- a/src/app/features/jugador/reservas/reservas.service.ts
+++ b/src/app/features/jugador/reservas/reservas.service.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { Observable } from 'rxjs';
-import { ReservationsResponse, ReservationResponse, AvailabilityResponse, AvailableTimesResponse, AvailableDatesResponse } from '../../../core/models/api-response.model';
+import {
+  ReservationsResponse, ReservationResponse, AvailabilityResponse, AvailableTimesResponse,
+  AvailableDatesResponse, CreatePaymentIntentResponse
+} from '../../../core/models/api-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -34,5 +37,9 @@ export class ReservasService {
     return this.http.get<AvailableDatesResponse>(`${this.apiUrl}/available-dates`, {
       params: { pitch_id: pitchId.toString(), start_date: startDate, end_date: endDate }
     });
+  }
+
+  createPaymentIntent(data: { pitch_id: number; start_at: string; duration: number }): Observable<CreatePaymentIntentResponse> {
+    return this.http.post<CreatePaymentIntentResponse>(`${this.apiUrl}/create-payment-intent`, data);
   }
 }

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,4 +1,5 @@
 export const environment = {
     production: false,
-    apiUrl: 'http://localhost:8000/api'
+    apiUrl: 'http://localhost:8000/api',
+    stripePublicKey: 'pk_test_51RYEUFRC8m9ymNwVY3ExAjTC3B8eO3vGskCeKxVGbEjHNDTAJxWntvIM5ZefEftv9B71bsMDQYg6HbgOML8dg6ZD00aI2hH8nh',
 };


### PR DESCRIPTION
Este pull request integra la funcionalidad de pagos con Stripe, permitiendo a los usuarios completar el pago durante el proceso de reserva.

Cambios:
Añadida la dependencia del SDK de Stripe JS.

Actualizadas las rutas del jugador para el flujo de pago.

Modificado campos.component.html para la nueva ruta de reserva.

Creado ReservationStateService con la interfaz ReservationData.

Actualizado reservar.component para incluir el flujo de creación del payment intent.

Creado pagar.component para el pago con Stripe.

Añadido el método createPaymentIntent al servicio reservas.service.

Actualizado environment.ts con la clave pública de Stripe.

Objetivo:
Permitir que los usuarios paguen sus reservas utilizando Stripe.

Mantener el estado de la reserva de forma segura entre componentes.

Mejorar la experiencia de usuario con una página de pago dedicada.

Pruebas:
Verificado que el flujo de pago funciona desde la selección de la reserva hasta la confirmación del pago.

Confirmado que el spinner de carga aparece durante las llamadas a la API.

Probado el manejo de errores para pagos inválidos o datos incorrectos de la reserva.

Comprobado que se navega a la página de reservas con un mensaje de éxito tras el pago.