### PR TITLE
Add Pitch Management UI for Establishments

### DIFF
--- a/src/app/core/models/api-response.model.ts
+++ b/src/app/core/models/api-response.model.ts
@@ -17,6 +17,11 @@ export interface PitchesResponse {
     pitches: Pitch[];
 }
 
+export interface PitchResponse {
+    message: string;
+    pitch: Pitch;
+}
+
 export interface ReservationsResponse {
     message: string;
     reservations: Reservation[];

--- a/src/app/core/models/pitch.model.ts
+++ b/src/app/core/models/pitch.model.ts
@@ -4,5 +4,8 @@ export interface Pitch {
     id: number;
     name: string;
     location: string;
+    price: number;
+    description: string;
     establishment?: Establishment;
+    deleted_at?: Date;
 }

--- a/src/app/features/establecimiento/campos/add-pitch/add-pitch.component.html
+++ b/src/app/features/establecimiento/campos/add-pitch/add-pitch.component.html
@@ -1,0 +1,77 @@
+<h2>Añadir Campo</h2>
+
+<app-loading [isLoading]="isLoading"></app-loading>
+
+@if (!isLoading) {
+<form [formGroup]="pitchForm" (ngSubmit)="onSubmit()" class="card p-4">
+    <div class="form-group">
+        <label for="name">Nombre</label>
+        <input id="name" formControlName="name" type="text" class="form-control"
+            [class.is-invalid]="pitchForm.get('name')?.invalid && pitchForm.get('name')?.touched" />
+        @if (pitchForm.get('name')?.invalid && pitchForm.get('name')?.touched) {
+        <div class="invalid-feedback">
+            @if (pitchForm.get('name')?.errors?.['required']) {
+            El nombre es obligatorio.
+            }
+            @if (pitchForm.get('name')?.errors?.['maxlength']) {
+            El nombre no puede exceder los 255 caracteres.
+            }
+        </div>
+        }
+    </div>
+
+    <div class="form-group">
+        <label for="location">Ubicación</label>
+        <input id="location" formControlName="location" type="text" class="form-control"
+            [class.is-invalid]="pitchForm.get('location')?.invalid && pitchForm.get('location')?.touched" />
+        @if (pitchForm.get('location')?.invalid && pitchForm.get('location')?.touched) {
+        <div class="invalid-feedback">
+            @if (pitchForm.get('location')?.errors?.['required']) {
+            La ubicación es obligatoria.
+            }
+            @if (pitchForm.get('location')?.errors?.['maxlength']) {
+            La ubicación no puede exceder los 255 caracteres.
+            }
+        </div>
+        }
+    </div>
+
+    <div class="form-group">
+        <label for="price">Precio (€/hora)</label>
+        <input id="price" formControlName="price" type="number" step="0.01" class="form-control"
+            [class.is-invalid]="pitchForm.get('price')?.invalid && pitchForm.get('price')?.touched" />
+        @if (pitchForm.get('price')?.invalid && pitchForm.get('price')?.touched) {
+        <div class="invalid-feedback">
+            @if (pitchForm.get('price')?.errors?.['required']) {
+            El precio es obligatorio.
+            }
+            @if (pitchForm.get('price')?.errors?.['min']) {
+            El precio no puede ser negativo.
+            }
+        </div>
+        }
+    </div>
+
+    <div class="form-group">
+        <label for="description">Descripción</label>
+        <textarea id="description" formControlName="description" class="form-control" rows="4"
+            [class.is-invalid]="pitchForm.get('description')?.invalid && pitchForm.get('description')?.touched"></textarea>
+        @if (pitchForm.get('description')?.invalid && pitchForm.get('description')?.touched) {
+        <div class="invalid-feedback">
+            La descripción no puede exceder los 1000 caracteres.
+        </div>
+        }
+    </div>
+
+    <div class="d-flex justify-content-end">
+        <button type="button" class="btn btn-secondary me-2" (click)="cancel()">Cancelar</button>
+        <button type="submit" class="btn btn-success" [disabled]="pitchForm.invalid || isLoading">
+            Guardar
+        </button>
+    </div>
+</form>
+}
+
+@if (error) {
+<div class="alert alert-danger mt-3">{{ error }}</div>
+}

--- a/src/app/features/establecimiento/campos/add-pitch/add-pitch.component.scss
+++ b/src/app/features/establecimiento/campos/add-pitch/add-pitch.component.scss
@@ -1,0 +1,29 @@
+.card {
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.form-control {
+    transition: border-color 0.2s;
+
+    &:focus {
+        border-color: #28a745;
+        box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);
+    }
+}
+
+.invalid-feedback {
+    font-size: 0.85rem;
+}
+
+@media (max-width: 576px) {
+    .card {
+        padding: 1rem;
+    }
+
+    .btn {
+        width: 100%;
+        margin-bottom: 0.5rem;
+    }
+}

--- a/src/app/features/establecimiento/campos/add-pitch/add-pitch.component.ts
+++ b/src/app/features/establecimiento/campos/add-pitch/add-pitch.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { PitchsService } from '../campos.service';
+import { Router } from '@angular/router';
+import { LoadingComponent } from '../../../../shared/components/loading/loading.component';
+
+@Component({
+  selector: 'app-add-pitch',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, LoadingComponent],
+  templateUrl: './add-pitch.component.html',
+  styleUrls: ['./add-pitch.component.scss'],
+})
+export class AddPitchComponent implements OnInit {
+  pitchForm: FormGroup;
+  error: string | null = null;
+  isLoading: boolean = false;
+
+  constructor(
+    private fb: FormBuilder,
+    private pitchsService: PitchsService,
+    private router: Router
+  ) {
+    this.pitchForm = this.fb.group({
+      name: ['', [Validators.required, Validators.maxLength(255)]],
+      location: ['', [Validators.required, Validators.maxLength(255)]],
+      price: [0, [Validators.required, Validators.min(0)]],
+      description: ['', [Validators.maxLength(1000)]],
+    });
+  }
+
+  ngOnInit(): void { }
+
+  onSubmit(): void {
+    if (this.pitchForm.invalid) return;
+
+    this.isLoading = true;
+    this.pitchsService.createPitch(this.pitchForm.value).subscribe({
+      next: () => this.router.navigate(['/establecimiento/campos']),
+      error: (err) => this.error = 'Error al crear el campo: ' + (err.error?.message || err.message),
+      complete: () => this.isLoading = false
+    });
+  }
+
+  cancel(): void {
+    this.router.navigate(['/establecimiento/campos']);
+  }
+}

--- a/src/app/features/establecimiento/campos/campos.component.html
+++ b/src/app/features/establecimiento/campos/campos.component.html
@@ -1,15 +1,51 @@
-<h2>Campos</h2>
+<h2>Gestión de Campos</h2>
 
 <app-loading [isLoading]="isLoading"></app-loading>
 
 @if (!isLoading) {
 <div class="content">
     @if (pitches.length) {
-    <ul class="list-group">
-        @for (pitch of pitches; track pitch.id) {
-        <li class="list-group-item">{{ pitch.name }} - {{ pitch.location }}</li>
-        }
-    </ul>
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th>Nombre</th>
+                    <th>Ubicación</th>
+                    <th>Precio</th>
+                    <th>Descripción</th>
+                    <th>Estado</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for (pitch of pitches; track pitch.id) {
+                <tr>
+                    <td>{{ pitch.name }}</td>
+                    <td>{{ pitch.location }}</td>
+                    <td>{{ pitch.price | currency:'EUR' }}</td>
+                    <td>{{ pitch.description || '-' }}</td>
+                    <td>
+                        @if (pitch.deleted_at) {
+                        <span class="badge bg-danger">Eliminado</span>
+                        } @else {
+                        <span class="badge bg-success">Activo</span>
+                        }
+                    </td>
+                    <td>
+                        <button class="btn btn-sm btn-primary me-2" (click)="editPitch(pitch.id)"
+                            [disabled]="pitch.deleted_at">
+                            Editar
+                        </button>
+                        <button class="btn btn-sm btn-danger" (click)="deletePitch(pitch.id)"
+                            [disabled]="pitch.deleted_at">
+                            Eliminar
+                        </button>
+                    </td>
+                </tr>
+                }
+            </tbody>
+        </table>
+    </div>
     } @else if (!pitches.length && !error) {
     <div class="alert alert-info">
         No hay campos registrados.
@@ -19,5 +55,6 @@
         {{ error }}
     </div>
     }
+    <button class="btn btn-success mt-3" (click)="addPitch()">Añadir Campo</button>
 </div>
 }

--- a/src/app/features/establecimiento/campos/campos.component.scss
+++ b/src/app/features/establecimiento/campos/campos.component.scss
@@ -1,3 +1,23 @@
-.error {
-    color: red;
+.table-responsive {
+    margin-bottom: 1rem;
+}
+
+.badge {
+    font-size: 0.9rem;
+    padding: 0.5rem;
+}
+
+.btn-sm {
+    padding: 0.4rem 0.8rem;
+}
+
+@media (max-width: 576px) {
+    .table {
+        font-size: 0.9rem;
+    }
+
+    .btn-sm {
+        width: 100%;
+        margin-bottom: 0.5rem;
+    }
 }

--- a/src/app/features/establecimiento/campos/campos.component.ts
+++ b/src/app/features/establecimiento/campos/campos.component.ts
@@ -1,8 +1,9 @@
 import { Component, OnInit } from '@angular/core';
-import { PitchsService } from './../../establecimiento/campos/campos.service';
+import { PitchsService } from './campos.service';
 import { Pitch } from '../../../core/models/pitch.model';
 import { CommonModule } from '@angular/common';
 import { LoadingComponent } from '../../../shared/components/loading/loading.component';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-establecimiento-campos',
@@ -15,17 +16,41 @@ export class CamposComponent implements OnInit {
   pitches: Pitch[] = [];
   error: string | null = null;
   isLoading: boolean = true;
-  
-  constructor(private pitchesService: PitchsService) { }
-  
+
+  constructor(
+    private pitchsService: PitchsService,
+    private router: Router
+  ) { }
+
   ngOnInit(): void {
-    this.pitchesService.getPitches().subscribe({
+    this.loadPitches();
+  }
+
+  loadPitches(): void {
+    this.isLoading = true;
+    this.pitchsService.getPitchesForEstablishment().subscribe({
       next: (response) => this.pitches = response.pitches,
-      error: (err) => {
-        this.error = 'Error al obtener los campos: ' + (err.error?.message || err.message);
-        console.error('Error al obtener campos:', err);
-      },
-      complete: () => this.isLoading = false,
+      error: (err) => this.error = 'Error al obtener los campos: ' + (err.error?.message || err.message),
+      complete: () => this.isLoading = false
     });
+  }
+
+  addPitch(): void {
+    this.router.navigate(['establecimiento/campos/add']);
+  }
+
+  editPitch(id: number): void {
+    this.router.navigate([`establecimiento/campos/edit/${id}`]);
+  }
+
+  deletePitch(id: number): void {
+    if (confirm('¿Estás seguro de que deseas marcar este campo como eliminado?')) {
+      this.isLoading = true;
+      this.pitchsService.deletePitch(id).subscribe({
+        next: () => this.loadPitches(),
+        error: (err) => this.error = 'Error al eliminar el campo: ' + (err.error?.message || err.message),
+        complete: () => this.isLoading = false
+      });
+    }
   }
 }

--- a/src/app/features/establecimiento/campos/campos.service.ts
+++ b/src/app/features/establecimiento/campos/campos.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../../environments/environment';
 import { Observable } from 'rxjs';
-import { PitchesResponse } from '../../../core/models/api-response.model';
+import { PitchesResponse, PitchResponse } from '../../../core/models/api-response.model';
 
 @Injectable({
   providedIn: 'root'
@@ -14,5 +14,25 @@ export class PitchsService {
 
   getPitches(): Observable<PitchesResponse> {
     return this.http.get<PitchesResponse>(this.apiUrl);
+  }
+
+  getPitchesForEstablishment(): Observable<PitchesResponse> {
+    return this.http.get<PitchesResponse>(this.apiUrl);
+  }
+
+  getPitch(id: number): Observable<PitchResponse> {
+    return this.http.get<PitchResponse>(`${this.apiUrl}/${id}`);
+  }
+
+  createPitch(pitch: { name: string; location: string; price: number; description?: string }): Observable<PitchResponse> {
+    return this.http.post<PitchResponse>(this.apiUrl, pitch);
+  }
+
+  updatePitch(id: number, pitch: { name: string; location: string; price: number; description?: string }): Observable<PitchResponse> {
+    return this.http.put<PitchResponse>(`${this.apiUrl}/${id}`, pitch);
+  }
+
+  deletePitch(id: number): Observable<PitchResponse> {
+    return this.http.delete<PitchResponse>(`${this.apiUrl}/${id}`);
   }
 }

--- a/src/app/features/establecimiento/campos/edit-pitch/edit-pitch.component.html
+++ b/src/app/features/establecimiento/campos/edit-pitch/edit-pitch.component.html
@@ -1,0 +1,77 @@
+<h2>Editar Campo</h2>
+
+<app-loading [isLoading]="isLoading"></app-loading>
+
+@if (!isLoading) {
+<form [formGroup]="pitchForm" (ngSubmit)="onSubmit()" class="card p-4">
+  <div class="form-group">
+    <label for="name">Nombre</label>
+    <input id="name" formControlName="name" type="text" class="form-control"
+      [class.is-invalid]="pitchForm.get('name')?.invalid && pitchForm.get('name')?.touched" />
+    @if (pitchForm.get('name')?.invalid && pitchForm.get('name')?.touched) {
+    <div class="invalid-feedback">
+      @if (pitchForm.get('name')?.errors?.['required']) {
+      El nombre es obligatorio.
+      }
+      @if (pitchForm.get('name')?.errors?.['maxlength']) {
+      El nombre no puede exceder los 255 caracteres.
+      }
+    </div>
+    }
+  </div>
+
+  <div class="form-group">
+    <label for="location">Ubicación</label>
+    <input id="location" formControlName="location" type="text" class="form-control"
+      [class.is-invalid]="pitchForm.get('location')?.invalid && pitchForm.get('location')?.touched" />
+    @if (pitchForm.get('location')?.invalid && pitchForm.get('location')?.touched) {
+    <div class="invalid-feedback">
+      @if (pitchForm.get('location')?.errors?.['required']) {
+      La ubicación es obligatoria.
+      }
+      @if (pitchForm.get('location')?.errors?.['maxlength']) {
+      La ubicación no puede exceder los 255 caracteres.
+      }
+    </div>
+    }
+  </div>
+
+  <div class="form-group">
+    <label for="price">Precio (€/hora)</label>
+    <input id="price" formControlName="price" type="number" step="0.01" class="form-control"
+      [class.is-invalid]="pitchForm.get('price')?.invalid && pitchForm.get('price')?.touched" />
+    @if (pitchForm.get('price')?.invalid && pitchForm.get('price')?.touched) {
+    <div class="invalid-feedback">
+      @if (pitchForm.get('price')?.errors?.['required']) {
+      El precio es obligatorio.
+      }
+      @if (pitchForm.get('price')?.errors?.['min']) {
+      El precio no puede ser negativo.
+      }
+    </div>
+    }
+  </div>
+
+  <div class="form-group">
+    <label for="description">Descripción</label>
+    <textarea id="description" formControlName="description" class="form-control" rows="4"
+      [class.is-invalid]="pitchForm.get('description')?.invalid && pitchForm.get('description')?.touched"></textarea>
+    @if (pitchForm.get('description')?.invalid && pitchForm.get('description')?.touched) {
+    <div class="invalid-feedback">
+      La descripción no puede exceder los 1000 caracteres.
+    </div>
+    }
+  </div>
+
+  <div class="d-flex justify-content-end">
+    <button type="button" class="btn btn-secondary me-2" (click)="cancel()">Cancelar</button>
+    <button type="submit" class="btn btn-success" [disabled]="pitchForm.invalid || isLoading">
+      Guardar
+    </button>
+  </div>
+</form>
+}
+
+@if (error) {
+<div class="alert alert-danger mt-3">{{ error }}</div>
+}

--- a/src/app/features/establecimiento/campos/edit-pitch/edit-pitch.component.scss
+++ b/src/app/features/establecimiento/campos/edit-pitch/edit-pitch.component.scss
@@ -1,0 +1,29 @@
+.card {
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.form-control {
+    transition: border-color 0.2s;
+
+    &:focus {
+        border-color: #28a745;
+        box-shadow: 0 0 0 0.2rem rgba(40, 167, 69, 0.25);
+    }
+}
+
+.invalid-feedback {
+    font-size: 0.85rem;
+}
+
+@media (max-width: 576px) {
+    .card {
+        padding: 1rem;
+    }
+
+    .btn {
+        width: 100%;
+        margin-bottom: 0.5rem;
+    }
+}

--- a/src/app/features/establecimiento/campos/edit-pitch/edit-pitch.component.ts
+++ b/src/app/features/establecimiento/campos/edit-pitch/edit-pitch.component.ts
@@ -1,0 +1,79 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { PitchsService } from '../campos.service';
+import { Router, ActivatedRoute } from '@angular/router';
+import { LoadingComponent } from '../../../../shared/components/loading/loading.component';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-edit-pitch',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, LoadingComponent],
+  templateUrl: './edit-pitch.component.html',
+  styleUrls: ['./edit-pitch.component.scss'],
+})
+export class EditPitchComponent implements OnInit {
+  pitchForm: FormGroup;
+  error: string | null = null;
+  isLoading: boolean = false;
+  pitchId: number;
+
+  constructor(
+    private fb: FormBuilder,
+    private pitchsService: PitchsService,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {
+    this.pitchId = +this.route.snapshot.paramMap.get('id')!;
+    this.pitchForm = this.fb.group({
+      name: ['', [Validators.required, Validators.maxLength(255)]],
+      location: ['', [Validators.required, Validators.maxLength(255)]],
+      price: [0, [Validators.required, Validators.min(0)]],
+      description: ['', [Validators.maxLength(1000)]],
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadPitch();
+  }
+
+  loadPitch(): void {
+    this.isLoading = true;
+    this.pitchsService.getPitch(this.pitchId).subscribe({
+      next: (response) => {
+        const pitch = response.pitch;
+        if (pitch) {
+          this.pitchForm.patchValue({
+            name: pitch.name,
+            location: pitch.location,
+            price: pitch.price,
+            description: pitch.description || '',
+          });
+        } else {
+          this.error = 'Campo no encontrado';
+        }
+        this.isLoading = false;
+      },
+      error: (err) => {
+        this.error = 'Error al cargar el campo: ' + (err.error?.message || err.message);
+        this.isLoading = false;
+      },
+    });
+  }
+
+  onSubmit(): void {
+    if (this.pitchForm.invalid) return;
+
+    this.isLoading = true;
+    this.pitchsService.updatePitch(this.pitchId, this.pitchForm.value).subscribe({
+      next: () => this.router.navigate(['/establecimiento/campos']),
+      error: (err) => this.error = 'Error al actualizar el campo: ' + (err.error?.message || err.message),
+      complete: () => this.isLoading = false,
+    });
+  }
+
+  cancel(): void {
+    this.router.navigate(['/establecimiento/campos']);
+  }
+}

--- a/src/app/features/establecimiento/establecimiento.routes.ts
+++ b/src/app/features/establecimiento/establecimiento.routes.ts
@@ -1,7 +1,11 @@
 import { Routes } from '@angular/router';
 import { CamposComponent } from './campos/campos.component';
+import { AddPitchComponent } from './campos/add-pitch/add-pitch.component';
+import { EditPitchComponent } from './campos/edit-pitch/edit-pitch.component';
 
 export const establecimientoRoutes: Routes = [
     { path: 'campos', component: CamposComponent },
+    { path: 'campos/add', component: AddPitchComponent },
+    { path: 'campos/edit/:id', component: EditPitchComponent },
     { path: '', redirectTo: 'campos', pathMatch: 'full' }
 ];

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,3 +5,44 @@ body {
   margin: 0;
   font-family: Arial, sans-serif;
 }
+
+.btn {
+  border-radius: 4px;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.form-group {
+  margin-bottom: 1rem;
+
+  label {
+    font-weight: 500;
+    margin-bottom: 0.5rem;
+    display: block;
+  }
+
+  input,
+  textarea {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid #ced4da;
+    border-radius: 4px;
+    font-size: 1rem;
+  }
+}
+
+.alert {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+@media (max-width: 576px) {
+  .btn {
+    padding: 0.75rem;
+    font-size: 1.1rem;
+  }
+}


### PR DESCRIPTION
Este pull request añade una interfaz de usuario para que los establecimientos gestionen sus campos, incluyendo la visualización, creación y edición de campos.

Cambios:
Añadidos estilos globales para la interfaz de gestión de campos.

Actualizados los archivos api-response.model.ts y pitch.model.ts.

Añadidas rutas para establecimientos para la gestión de campos.

Creado el componente campos.component para la gestión de campos.

Creado PitchsService para la gestión de campos por parte del establecimiento.

Creado el componente add-pitch.component para añadir nuevos campos.

Creado el componente edit-pitch.component para editar campos existentes.

Objetivo:
Proporcionar a los establecimientos una interfaz para gestionar sus campos.

Garantizar la coherencia con las respuestas de la API del backend.

Mejorar la experiencia de usuario con diseño responsivo y validación de formularios.

Pruebas:
Verificado que los establecimientos pueden ver, añadir y editar campos.

Confirmado que los campos eliminados lógicamente se muestran como inactivos.

Probada la validación de formularios y el manejo de errores.

Asegurado que la navegación entre componentes funcione correctamente.