### PR TITLE
Add Reservation Management for Establishments

### DIFF
--- a/src/app/core/models/reservation.model.ts
+++ b/src/app/core/models/reservation.model.ts
@@ -2,7 +2,7 @@ import { Pitch } from './pitch.model';
 
 export interface Reservation {
     id: number;
-    player_id: number,
+    player: { id: number; name: string, email: string };
     start_at: Date,
     duration: number,
     price: number,
@@ -12,4 +12,5 @@ export interface Reservation {
     payment_method: string,
     cancellation_reason: string | null,
     cancellation_date: Date | null,
+    deleted_at?: Date;
 }

--- a/src/app/features/establecimiento/establecimiento.routes.ts
+++ b/src/app/features/establecimiento/establecimiento.routes.ts
@@ -2,10 +2,12 @@ import { Routes } from '@angular/router';
 import { CamposComponent } from './campos/campos.component';
 import { AddPitchComponent } from './campos/add-pitch/add-pitch.component';
 import { EditPitchComponent } from './campos/edit-pitch/edit-pitch.component';
+import { ReservationsComponent } from './reservations/reservations.component';
 
 export const establecimientoRoutes: Routes = [
     { path: 'campos', component: CamposComponent },
     { path: 'campos/add', component: AddPitchComponent },
     { path: 'campos/edit/:id', component: EditPitchComponent },
+    { path: 'reservas', component: ReservationsComponent },
     { path: '', redirectTo: 'campos', pathMatch: 'full' }
 ];

--- a/src/app/features/establecimiento/reservations/reservations.component.html
+++ b/src/app/features/establecimiento/reservations/reservations.component.html
@@ -1,0 +1,63 @@
+<h2>Gestión de Reservas</h2>
+
+<app-loading [isLoading]="isLoading"></app-loading>
+
+@if (!isLoading) {
+<div class="content">
+    @if (reservations.length) {
+    <div class="table-responsive">
+        <table class="table table-striped table-hover">
+            <thead>
+                <tr>
+                    <th>Campo</th>
+                    <th>Usuario</th>
+                    <th>Fecha y Hora</th>
+                    <th>Duración</th>
+                    <th>Estado</th>
+                    <th>Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for (reservation of reservations; track reservation.id) {
+                <tr>
+                    <td>{{ reservation.pitch.name }} ({{ reservation.pitch.location }})</td>
+                    <td>{{ reservation.player.name }}</td>
+                    <td>{{ reservation.start_at | date:'medium' }}</td>
+                    <td>{{ reservation.duration }} minutos</td>
+                    <td>
+                        @switch (reservation.status) {
+                        @case ('pending') {
+                        <span class="badge bg-warning">Pendiente</span>
+                        }
+                        @case ('confirmed') {
+                        <span class="badge bg-success">Confirmada</span>
+                        }
+                        @case ('cancelled') {
+                        <span class="badge bg-danger">Cancelada</span>
+                        }
+                        @default {
+                        <span class="badge bg-secondary">Desconocido</span>}
+                        }
+                    </td>
+                    <td>
+                        <button class="btn btn-sm btn-danger" (click)="cancelReservation(reservation.id)"
+                            [disabled]="reservation.deleted_at">
+                            Cancelar
+                        </button>
+                    </td>
+                </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+    } @else if (!reservations.length && !error) {
+    <div class="alert alert-info">
+        No hay reservas registradas.
+    </div>
+    } @else if (error) {
+    <div class="alert alert-danger">
+        {{ error }}
+    </div>
+    }
+</div>
+}

--- a/src/app/features/establecimiento/reservations/reservations.component.scss
+++ b/src/app/features/establecimiento/reservations/reservations.component.scss
@@ -1,0 +1,23 @@
+.table-responsive {
+    margin-bottom: 1rem;
+}
+
+.badge {
+    font-size: 0.9rem;
+    padding: 0.5rem;
+}
+
+.btn-sm {
+    padding: 0.4rem 0.8rem;
+}
+
+@media (max-width: 576px) {
+    .table {
+        font-size: 0.9rem;
+    }
+
+    .btn-sm {
+        width: 100%;
+        margin-bottom: 0.5rem;
+    }
+}

--- a/src/app/features/establecimiento/reservations/reservations.component.ts
+++ b/src/app/features/establecimiento/reservations/reservations.component.ts
@@ -1,0 +1,47 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LoadingComponent } from '../../../shared/components/loading/loading.component';
+import { ReservationsService } from './reservations.service';
+import { Reservation } from '../../../core/models/reservation.model';
+
+@Component({
+    selector: 'app-reservations',
+    standalone: true,
+    imports: [CommonModule, LoadingComponent],
+    templateUrl: './reservations.component.html',
+    styleUrls: ['./reservations.component.scss']
+})
+export class ReservationsComponent implements OnInit {
+    reservations: Reservation[] = [];
+    error: string | null = null;
+    isLoading: boolean = true;
+    cancellationReason: string = '';
+
+    constructor(
+        private reservationsService: ReservationsService,
+    ) { }
+
+    ngOnInit(): void {
+        this.loadReservations();
+    }
+
+    loadReservations(): void {
+        this.isLoading = true;
+        this.reservationsService.getReservations().subscribe({
+            next: (response) => this.reservations = response.reservations,
+            error: (err) => this.error = 'Error al obtener las reservas: ' + (err.error?.message || err.message),
+            complete: () => this.isLoading = false
+        });
+    }
+
+    cancelReservation(id: number): void {
+        if (confirm('¿Estás seguro de que deseas cancelar esta reserva?')) {
+            const reason = prompt('Motivo de la cancelación:') || 'Sin motivo especificado';
+            this.reservationsService.cancelReservation(id, reason).subscribe({
+                next: () => this.loadReservations(),
+                error: (err) => this.error = 'Error al cancelar la reserva: ' + (err.error?.message || err.message),
+                complete: () => { }
+            });
+        }
+    }
+}

--- a/src/app/features/establecimiento/reservations/reservations.service.ts
+++ b/src/app/features/establecimiento/reservations/reservations.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { environment } from '../../../../environments/environment';
+import { Observable } from 'rxjs';
+import { ReservationsResponse } from '../../../core/models/api-response.model';
+
+@Injectable({
+    providedIn: 'root'
+})
+export class ReservationsService {
+    private apiUrl = `${environment.apiUrl}/establishment/reservations`;
+
+    constructor(private http: HttpClient) { }
+
+    getReservations(): Observable<ReservationsResponse> {
+        return this.http.get<ReservationsResponse>(this.apiUrl);
+    }
+
+    cancelReservation(id: number, cancellation_reason: string): Observable<any> {
+        const headers = new HttpHeaders({ 'Content-Type': 'application/json' });
+        const body = { cancellation_reason };
+        return this.http.delete(`${this.apiUrl}/${id}`, { headers, body });
+    }
+}


### PR DESCRIPTION
Este pull request añade una interfaz de usuario para que los establecimientos gestionen las reservas de sus campos, incluyendo la visualización y cancelación de las mismas.

Cambios:
Actualizado reservation.model.ts con campos de cancelación.

Añadida la ruta reservas a las rutas de establecimiento.

Creado el componente reservations.component para la gestión de reservas.

Creado ReservationsService para la gestión de reservas del establecimiento.

Objetivo:
Proporcionar a los establecimientos una interfaz para ver y cancelar reservas.

Asegurar la coherencia con las respuestas de la API del backend.

Mejorar la experiencia de usuario con diseño responsivo y diálogos de confirmación.

Pruebas:
Verificado que los establecimientos pueden visualizar todas las reservas de sus campos.

Confirmado que las cancelaciones requieren confirmación y actualizan la interfaz.

Probado el manejo de errores y los estados de carga.

Asegurado que la navegación hacia la página de reservas funciona correctamente.
