### PR TITLE
Add Refund UI and Logic for Reservation Cancellation

### DIFF
--- a/src/app/core/models/reservation.model.ts
+++ b/src/app/core/models/reservation.model.ts
@@ -8,7 +8,7 @@ export interface Reservation {
     price: number,
     status: string,
     pitch: Pitch;
-    payment_status: string,
+    payment_status: 'pending' | 'completed' | 'failed' | 'refunded',
     payment_method: string,
     cancellation_reason: string | null,
     cancellation_date: Date | null,

--- a/src/app/features/establecimiento/reservations/reservations.component.html
+++ b/src/app/features/establecimiento/reservations/reservations.component.html
@@ -34,6 +34,9 @@
                         }
                         @case ('cancelled') {
                         <span class="badge bg-danger">Cancelada</span>
+                        @if (reservation.payment_status === 'refunded') {
+                        <span class="badge bg-info ms-2">Reembolsada</span>
+                        }
                         }
                         @default {
                         <span class="badge bg-secondary">Desconocido</span>}

--- a/src/app/features/establecimiento/reservations/reservations.component.ts
+++ b/src/app/features/establecimiento/reservations/reservations.component.ts
@@ -39,7 +39,7 @@ export class ReservationsComponent implements OnInit {
             const reason = prompt('Motivo de la cancelación:') || 'Sin motivo especificado';
             this.reservationsService.cancelReservation(id, reason).subscribe({
                 next: () => this.loadReservations(),
-                error: (err) => this.error = 'Error al cancelar la reserva: ' + (err.error?.message || err.message),
+                error: (err) => this.error = 'Error al cancelar o reembolsar la reserva: ' + (err.error?.message || err.message),
                 complete: () => { }
             });
         }


### PR DESCRIPTION
Este pull request actualiza la interfaz y la lógica para reflejar el estado de reembolso cuando un establecimiento cancela una reserva, integrándose con la funcionalidad de reembolso del backend.

Cambios:
Se actualiza reservation.model.ts para incluir el estado de reembolso.

Se actualiza reservations.component para mostrar el estado de reembolso.

Objetivo:
Proporcionar retroalimentación visual sobre el estado del reembolso a los establecimientos.

Garantizar la coherencia con la lógica de reembolso implementada en el backend.

Mejorar la experiencia de usuario con razones de cancelación dinámicas.

Pruebas:
Verificado que las reservas reembolsadas muestran la insignia 'Reembolsada'.

Confirmado que la cancelación solicita un motivo y actualiza correctamente la interfaz.

Probado el manejo de errores en casos de fallos al cancelar o reembolsar.