### PR TITLE
Add Dynamic Pricing UI and Logic

### DIFF
--- a/src/app/core/services/reservation-state.service.ts
+++ b/src/app/core/services/reservation-state.service.ts
@@ -5,6 +5,7 @@ interface ReservationData {
     start_at: string;
     duration: number;
     client_secret?: string;
+    price_hour: number,
 }
 
 @Injectable({
@@ -14,7 +15,7 @@ export class ReservationStateService {
 
     private reservationData: ReservationData | null = null;
 
-    setReservationData(data: { pitch_id: number; start_at: string; duration: number; client_secret?: string }) {
+    setReservationData(data: { pitch_id: number; start_at: string; duration: number; price_hour:number, client_secret?: string }) {
         this.reservationData = data;
     }
 

--- a/src/app/features/jugador/campos/campos.component.html
+++ b/src/app/features/jugador/campos/campos.component.html
@@ -14,6 +14,7 @@
     <div class="pitch-card">
       <h3>{{ pitch.name }}</h3>
       <p><strong>Ubicación:</strong> {{ pitch.location }}</p>
+      <p><strong>Precio la hora:</strong> {{pitch.price}}</p>
       <p><strong>Establecimiento:</strong> {{ pitch?.establishment?.name }}</p>
       <div class="actions">
         <a [routerLink]="['/jugador/campo', pitch.id, 'detalles']" class="btn btn-details">Ver Detalles</a>

--- a/src/app/features/jugador/campos/reservar/pagar/pagar.component.ts
+++ b/src/app/features/jugador/campos/reservar/pagar/pagar.component.ts
@@ -69,6 +69,8 @@ export class PagarComponent implements OnInit, OnDestroy {
       return;
     }
 
+    this.amount = reservationData.price_hour * reservationData.duration / 60;
+
     try {
       if (reservationData && reservationData.client_secret) {
 

--- a/src/app/features/jugador/campos/reservar/reservar.component.html
+++ b/src/app/features/jugador/campos/reservar/reservar.component.html
@@ -7,6 +7,7 @@
   @if (pitch) {
   <div>
     <p><strong>Campo:</strong> {{ pitch.name }} - {{ pitch.location }}</p>
+    <p><strong>Precio la hora:</strong> {{pitch.price}}</p>
 
     <!-- Calendario -->
     <app-calendar [pitch]="pitch" [minDate]="minDate" [maxDate]="maxDate"

--- a/src/app/features/jugador/campos/reservar/reservar.component.ts
+++ b/src/app/features/jugador/campos/reservar/reservar.component.ts
@@ -180,6 +180,7 @@ export class ReservaFormComponent implements OnInit {
     const paymentIntentData = {
       pitch_id: this.pitch.id,
       start_at: startAt,
+      price_hour: this.pitch.price,
       duration: this.duration
     };
 
@@ -189,6 +190,7 @@ export class ReservaFormComponent implements OnInit {
         this.reservationStateService.setReservationData({
           pitch_id: this.pitch.id,
           start_at: startAt,
+          price_hour: this.pitch.price,
           duration: this.duration,
           client_secret: response.client_secret
         });


### PR DESCRIPTION
Este pull request actualiza el frontend para soportar precios dinámicos basados en la duración de la reserva, integrándose con la nueva lógica de precios del backend.

Cambios:
Se añade ReservationStateService para gestionar los datos de la reserva, incluyendo price_hour.

Se actualiza ReservarComponent para usar precios dinámicos y pasar price_hour.

Se actualiza PagarComponent para calcular el precio dinámicamente según la duración.

Se actualiza CamposComponent para mostrar el precio la hora al visualizar la lista de campos

Objetivo:
Mostrar y calcular el precio de forma dinámica en función de la duración seleccionada.

Asegurar consistencia con los cálculos de precios del backend.

Mejorar la experiencia de usuario mostrando claramente el coste de la reserva.

Pruebas:
Verificado que el precio se actualiza correctamente en la interfaz según la duración (60, 90, 120 minutos).

Confirmado que el importe del pago en PagarComponent coincide con el cálculo del backend.

Probado el flujo de navegación y reserva con diferentes duraciones.

